### PR TITLE
Add client and server QBCore TypeScript wrappers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/README.md
+++ b/README.md
@@ -1,2 +1,71 @@
 # qbcore-extended
-Extend QBCore with a TypeScript Library
+
+TypeScript utilities for QBCore that simplify working with the core object and
+common events.
+
+## Installation
+
+```bash
+npm install qbcore-extended
+```
+
+## Usage
+
+### Client
+
+```typescript
+import QBCore from 'qbcore-extended/client';
+
+QBCore.onPlayerLoaded = (player) => {
+  emit('chat:addMessage', { args: ['[TS]', `Client says: ${player.citizenid} loaded.`] });
+};
+
+QBCore.onPlayerUnload = () => {
+  emit('chat:addMessage', { args: ['[TS]', 'Client says: player unloaded.'] });
+};
+```
+
+### Server
+
+```typescript
+import QBCore from 'qbcore-extended/server';
+
+QBCore.onPlayerLoaded = (player) => {
+  console.log(`Player loaded: ${player.PlayerData.citizenid}`);
+};
+
+QBCore.onPlayerUnload = (playerId) => {
+  console.log(`Player unloaded: ${playerId}`);
+};
+```
+
+You can also import both sides from the root entry point:
+
+```typescript
+import QBCore from 'qbcore-extended';
+
+QBCore.Client.onPlayerLoaded = () => {};
+QBCore.Client.onPlayerUnload = () => {};
+QBCore.Server.onPlayerLoaded = () => {};
+QBCore.Server.onPlayerUnload = () => {};
+```
+
+The `core` property exposes the original QBCore object if you need to call
+additional functions.
+
+### Server native thread affinity
+
+CitizenFX's JavaScript runtime requires certain server natives to run on the
+main game thread. The library exposes helpers so you don't need to call
+`setImmediate` manually:
+
+```typescript
+import { Natives, runOnMainThread } from 'qbcore-extended/server';
+
+// Automatically deferred via proxy
+Natives.SetPlayerRoutingBucket(playerId, 0);
+
+// Manual wrapper for custom references
+const giveWeapon = runOnMainThread(GiveWeaponToPed);
+giveWeapon(playerPed, weaponHash, 250, false, false);
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,46 @@
+{
+  "name": "qbcore-extended",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "qbcore-extended",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@citizenfx/client": "^2.0.19032-1",
+        "@citizenfx/server": "^2.0.19032-1",
+        "typescript": "^5.3.3"
+      }
+    },
+    "node_modules/@citizenfx/client": {
+      "version": "2.0.19032-1",
+      "resolved": "https://registry.npmjs.org/@citizenfx/client/-/client-2.0.19032-1.tgz",
+      "integrity": "sha512-LsuhXfOWl19xndeIpbM0/zppJWPMukqQLIusBjIyaC5gf6HYulDqZrr3RjmUwKbtCJSOTF361b5nxzhAn2haag==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@citizenfx/server": {
+      "version": "2.0.19032-1",
+      "resolved": "https://registry.npmjs.org/@citizenfx/server/-/server-2.0.19032-1.tgz",
+      "integrity": "sha512-A8mTtlr+DnFaTvZ3lLhUbzYXYPxnzTLi0T7vHqXoG6sFSONCg28QaOBNy39zqjKHKpFH9M/ubNId/XwFJ4vGHA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "qbcore-extended",
+  "version": "0.1.0",
+  "description": "TypeScript utilities for QBCore",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./client": {
+      "require": "./dist/client.js",
+      "types": "./dist/client.d.ts"
+    },
+    "./server": {
+      "require": "./dist/server.js",
+      "types": "./dist/server.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "npm run build"
+  },
+  "keywords": ["qbcore", "fivem", "typescript"],
+  "author": "",
+  "license": "MIT",
+  "devDependencies": {
+    "@citizenfx/client": "^2.0.19032-1",
+    "@citizenfx/server": "^2.0.19032-1",
+    "typescript": "^5.3.3"
+  }
+}

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,0 +1,47 @@
+/// <reference types="@citizenfx/client" />
+
+/**
+ * QBCore Extended TypeScript wrapper.
+ * Provides typed helpers for obtaining the core object and listening
+ * for basic events.
+ */
+
+export type PlayerLoadedHandler = (player: any) => void;
+export type PlayerUnloadHandler = () => void;
+
+export class QBCoreClient {
+  public core: any;
+  private _onPlayerLoaded?: PlayerLoadedHandler;
+  private _onPlayerUnload?: PlayerUnloadHandler;
+
+  constructor() {
+    // Retrieve the QBCore object from the qb-core resource exports
+    this.core = (globalThis as any).exports['qb-core'].GetCoreObject();
+    on('QBCore:Client:OnPlayerLoaded', () => {
+      this._onPlayerLoaded?.(this.core.PlayerData);
+    });
+    on('QBCore:Client:OnPlayerUnload', () => {
+      this._onPlayerUnload?.();
+    });
+  }
+
+  get onPlayerLoaded(): PlayerLoadedHandler | undefined {
+    return this._onPlayerLoaded;
+  }
+
+  set onPlayerLoaded(handler: PlayerLoadedHandler | undefined) {
+    this._onPlayerLoaded = handler;
+  }
+
+  get onPlayerUnload(): PlayerUnloadHandler | undefined {
+    return this._onPlayerUnload;
+  }
+
+  set onPlayerUnload(handler: PlayerUnloadHandler | undefined) {
+    this._onPlayerUnload = handler;
+  }
+}
+
+const QBCore = new QBCoreClient();
+
+export default QBCore;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,6 @@
+import Client from './client';
+import Server from './server';
+
+export { Client, Server };
+
+export default { Client, Server };

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,75 @@
+/// <reference types="@citizenfx/server" />
+
+/**
+ * QBCore Extended TypeScript wrapper for server scripts.
+ */
+export type PlayerLoadedHandler = (player: any) => void;
+export type PlayerUnloadHandler = (playerId: number) => void;
+
+export class QBCoreServer {
+  public core: any;
+  private _onPlayerLoaded?: PlayerLoadedHandler;
+  private _onPlayerUnload?: PlayerUnloadHandler;
+
+  constructor() {
+    // Retrieve the QBCore object from the qb-core resource exports
+    this.core = (globalThis as any).exports['qb-core'].GetCoreObject();
+    on('QBCore:Server:PlayerLoaded', (player: any) => {
+      this._onPlayerLoaded?.(player);
+    });
+    on('QBCore:Server:OnPlayerUnload', (playerId: number) => {
+      this._onPlayerUnload?.(playerId);
+    });
+  }
+
+  get onPlayerLoaded(): PlayerLoadedHandler | undefined {
+    return this._onPlayerLoaded;
+  }
+
+  set onPlayerLoaded(handler: PlayerLoadedHandler | undefined) {
+    this._onPlayerLoaded = handler;
+  }
+
+  get onPlayerUnload(): PlayerUnloadHandler | undefined {
+    return this._onPlayerUnload;
+  }
+
+  set onPlayerUnload(handler: PlayerUnloadHandler | undefined) {
+    this._onPlayerUnload = handler;
+  }
+}
+
+/**
+ * Wrap a server native so it runs on the next tick, satisfying thread affinity
+ * requirements described in the CitizenFX JavaScript runtime docs.
+ */
+export function runOnMainThread<T extends (...args: any[]) => any>(
+  nativeFn: T,
+): (...args: Parameters<T>) => void {
+  return (...args: Parameters<T>) => {
+    setImmediate(() => nativeFn(...args));
+  };
+}
+
+/**
+ * Proxy that automatically defers server natives to the next tick.
+ * Usage: `Natives.SetPlayerRoutingBucket(playerId, bucket)`.
+ */
+export const Natives: Record<string, any> = new Proxy(
+  {},
+  {
+    get(_target, prop: string) {
+      const fn = (globalThis as any)[prop];
+      if (typeof fn !== 'function') {
+        return fn;
+      }
+      return (...args: any[]) => {
+        setImmediate(() => fn(...args));
+      };
+    },
+  },
+);
+
+const QBCore = new QBCoreServer();
+
+export default QBCore;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "commonjs",
+    "declaration": true,
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- expose separate QBCore client and server wrappers
- map npm exports for `qbcore-extended/client` and `qbcore-extended/server`
- document usage for both sides
- add player unload hooks and document their usage
- provide server-native helpers that automatically defer to the main thread

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c047d1db84832e85eba0cc866f9367