### PR TITLE
feat: expose shared helpers and job data

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,34 @@ QBCore.Server.onPlayerUnload = () => {};
 The `core` property exposes the original QBCore object if you need to call
 additional functions.
 
+### Shared utilities and jobs
+
+Both client and server wrappers expose QBCore's shared helpers and job
+configuration:
+
+```typescript
+// Random plate using QBCore's helper
+const plate = QBCore.shared.RandomStr(4);
+
+// Access job definitions
+const police = QBCore.jobs['police'];
+```
+
+### Server helpers
+
+The server wrapper includes shortcuts for common QBCore functions and command
+registration:
+
+```typescript
+// Fetch a player by source
+const player = QBCore.getPlayer(source);
+
+// Register a simple command
+QBCore.registerCommand('ping', 'Replies with pong', (src) => {
+  console.log(`${src} pinged`);
+});
+```
+
 ### Server native thread affinity
 
 CitizenFX's JavaScript runtime requires certain server natives to run on the

--- a/src/client.ts
+++ b/src/client.ts
@@ -6,17 +6,24 @@
  * for basic events.
  */
 
+import type { Shared, Job } from './types';
+
 export type PlayerLoadedHandler = (player: any) => void;
 export type PlayerUnloadHandler = () => void;
 
 export class QBCoreClient {
   public core: any;
+  public shared: Shared;
+  public jobs: Record<string, Job>;
   private _onPlayerLoaded?: PlayerLoadedHandler;
   private _onPlayerUnload?: PlayerUnloadHandler;
 
   constructor() {
     // Retrieve the QBCore object from the qb-core resource exports
     this.core = (globalThis as any).exports['qb-core'].GetCoreObject();
+    this.shared = this.core.Shared as Shared;
+    this.jobs = this.shared.Jobs;
+
     on('QBCore:Client:OnPlayerLoaded', () => {
       this._onPlayerLoaded?.(this.core.PlayerData);
     });
@@ -39,6 +46,10 @@ export class QBCoreClient {
 
   set onPlayerUnload(handler: PlayerUnloadHandler | undefined) {
     this._onPlayerUnload = handler;
+  }
+
+  getJob(name: string): Job | undefined {
+    return this.jobs[name];
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 import Client from './client';
 import Server from './server';
-
 export { Client, Server };
-
+export * from './types';
 export default { Client, Server };

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,17 +3,26 @@
 /**
  * QBCore Extended TypeScript wrapper for server scripts.
  */
+import type { Shared, Job, ServerFunctions, CommandHandler } from './types';
+
 export type PlayerLoadedHandler = (player: any) => void;
 export type PlayerUnloadHandler = (playerId: number) => void;
 
 export class QBCoreServer {
   public core: any;
+  public shared: Shared;
+  public jobs: Record<string, Job>;
+  public functions: ServerFunctions;
   private _onPlayerLoaded?: PlayerLoadedHandler;
   private _onPlayerUnload?: PlayerUnloadHandler;
 
   constructor() {
     // Retrieve the QBCore object from the qb-core resource exports
     this.core = (globalThis as any).exports['qb-core'].GetCoreObject();
+    this.shared = this.core.Shared as Shared;
+    this.jobs = this.shared.Jobs;
+    this.functions = this.core.Functions as ServerFunctions;
+
     on('QBCore:Server:PlayerLoaded', (player: any) => {
       this._onPlayerLoaded?.(player);
     });
@@ -36,6 +45,28 @@ export class QBCoreServer {
 
   set onPlayerUnload(handler: PlayerUnloadHandler | undefined) {
     this._onPlayerUnload = handler;
+  }
+
+  getPlayer(source: number): any {
+    return this.functions.GetPlayer(source);
+  }
+
+  getPlayers(): number[] {
+    return this.functions.GetPlayers();
+  }
+
+  getJob(name: string): Job | undefined {
+    return this.jobs[name];
+  }
+
+  registerCommand(
+    name: string,
+    help: string,
+    handler: CommandHandler,
+    opts: { args?: string[]; argsRequired?: boolean; restricted?: boolean } = {},
+  ): void {
+    const { args = [], argsRequired = false, restricted = false } = opts;
+    this.core.Commands.Add(name, help, args, argsRequired, handler, restricted);
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,35 @@
+export interface JobGrade {
+  name: string;
+  payment: number;
+  isboss?: boolean;
+}
+
+export interface Job {
+  label: string;
+  defaultDuty: boolean;
+  offDutyPay: boolean;
+  grades: Record<string, JobGrade>;
+}
+
+export interface Shared {
+  RandomStr(length: number): string;
+  RandomInt(length: number): string;
+  SplitStr(input: string, separator: string): string[];
+  Trim(input: string): string;
+  FirstToUpper(input: string): string;
+  Round(value: number, numDecimalPlaces?: number): number;
+  Jobs: Record<string, Job>;
+}
+
+export type CommandHandler = (
+  source: number,
+  args: string[],
+  raw: string,
+) => void;
+
+export interface ServerFunctions {
+  GetPlayer(source: number): any;
+  GetPlayerByCitizenId(citizenId: string): any;
+  GetPlayers(): number[];
+  GetIdentifier(source: number, idType?: string): string;
+}


### PR DESCRIPTION
## Summary
- add types for QBCore shared utilities and job definitions
- expose shared helpers, job data, and common server functions
- document shared helpers, jobs, and command registration in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c04e470d3c832e96d0233b35ad8242